### PR TITLE
Fix #77 by adding explicit sponsorhip statement

### DIFF
--- a/web/templates/index.md.tmpl
+++ b/web/templates/index.md.tmpl
@@ -58,7 +58,10 @@ For the course slides, click [here](https://jorisvandenbossche.github.io/{{ repo
 Found any typo or have a suggestion, see [how to contribute](./contributing.html).
 
 ## Meta
+
 Authors: Joris Van den Bossche, Stijn Van Hoey
+
+With the support of the Flemish Government.
 
 <img src="./static/img/logo_flanders+richtingmorgen.png" width="79%">
 <img src="./static/img/doctoralschoolsprofiel_hq_rgb_web.png" width="20%">

--- a/web/templates/slides.html.tmpl
+++ b/web/templates/slides.html.tmpl
@@ -19,6 +19,11 @@ Joris Van den Bossche, Stijn Van Hoey
 
 https://github.com/jorisvandenbossche/{{ repository }}
 
+<img src="./static/img/logo_flanders+richtingmorgen.png" width="79%">
+<img src="./static/img/doctoralschoolsprofiel_hq_rgb_web.png" width="20%">
+
+<small>_With the support of the Flemish Government._</small>
+
 ---
 class: center, middle
 


### PR DESCRIPTION
As most issues are tackled Q3 last year, I do think this is the main change to fix before we can setup the course notes, @jorisvandenbossche  can you check as well and if all fine, push the notebooks/data to the DS_version?

__note__ -> If I find time, I'll try to setup a first draft cheatsheet for this years editions, but that can be distributed during course as well